### PR TITLE
docs(faq/sc): includes link to Zinc documentation on FAQ of smart contracts FAQ page for zkSync.

### DIFF
--- a/docs/faq/sc.md
+++ b/docs/faq/sc.md
@@ -1,5 +1,13 @@
 # Smart contracts
 
+## Zinc
+
+Zinc is a framework for constructing R1CS-based SNARK circuits and smart contracts for zkSync platform. It includes a simple, safe and efficient high-level programming language for defining zero-knowledge circuits, and a ZKP-friendly runtime execution environment. Zinc is designed to make developing scalable and privacy-preserving smart contracts easy.
+
+Zinc [documentation](https://zinc.zksync.io/).
+
+Zinc on [GitHub](https://github.com/matter-labs/zinc).
+
 Zinc Alef, the testnet for smart contracts on zkSync is live with Curve Finance as the first resident dapp!
 
 Check out the [intro post](https://medium.com/@matterlabs/5a72c496b350).


### PR DESCRIPTION
Adding documentation links and some info on Zinc to the smart contracts FAQ page