### PR TITLE
Replace testnet links with more relevant ones

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -4,5 +4,6 @@
     "first-header-h1": false,
     "first-line-h1": false,
     "no-inline-html": false,
+    "no-trailing-punctuation": false,
     "line-length": { "line_length": 120 }
 }

--- a/docs/dev/sending_transactions.md
+++ b/docs/dev/sending_transactions.md
@@ -103,13 +103,11 @@ messages, it may be required to add this prefix manually if used signer doesn't 
 Transactions batch is a set of transactions that should succeed all together. If one of the batch transactions fails,
 all the transactions in this batch will fail as well.
 
-::: warning
-**Note on security:** In the current form, transaction batches is a server-side abstraction. Successful execution is
-checked pre-circuit, and information about batch is not passed into the circuit. Thus, if this feature is being used to
-pay fees in a different token, it is recommended to set the fee payment transaction last (so that server even in theory
-will be unable to execute the last transaction, but ignore other ones). In the future, the batches will be enforced in
-the circuit in order to increase the overall security of this feature.
-:::
+::: warning **Note on security:** In the current form, transaction batches is a server-side abstraction. Successful
+execution is checked pre-circuit, and information about batch is not passed into the circuit. Thus, if this feature is
+being used to pay fees in a different token, it is recommended to set the fee payment transaction last (so that server
+even in theory will be unable to execute the last transaction, but ignore other ones). In the future, the batches will
+be enforced in the circuit in order to increase the overall security of this feature. :::
 
 Currently, a batch is guaranteed to be able to successfully process a max of 50 transactions.
 

--- a/docs/faq/intro.md
+++ b/docs/faq/intro.md
@@ -8,7 +8,7 @@ zero-knowledge proofs and on-chain data availability to keep user's funds as saf
 While security is our paramount priority, user and developer experience are central to zkSync design. We obsessively
 seek out improvements that eliminate friction and complexity in order to make zkSync the most enjoyable platform on
 Ethereum, for both end-users and builders. The best way to get an impression about it is to
-[try out zkSync](https://testnet.zksync.io) yourself — it should only take 2 minutes.
+[try out zkSync](https://wallet.zksync.io) yourself — it should only take 2 minutes.
 
 <!-- markdownlint-disable line-length -->
 <iframe width="560" height="315" src="https://www.youtube.com/embed/el-9YYGN1nw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/docs/faq/wallets.md
+++ b/docs/faq/wallets.md
@@ -4,20 +4,28 @@
 
 ## What Ethereum wallets does zkSync support?
 
-Generally, you can safely send funds to any Ethereum address (even to exchanges and smart contracts). The owner of this address will always be able to claim the funds.
+Generally, you can safely send funds to any Ethereum address (even to exchanges and smart contracts). The owner of this
+address will always be able to claim the funds.
 
-The up-to-date list of the Etherum wallets that you can control from the zkSync web wallet can be found directly on [its homepage](https://wallet.zksync.io).
+The up-to-date list of the Etherum wallets that you can control from the zkSync web wallet can be found directly on
+[its homepage](https://wallet.zksync.io).
 
-To control an address programmatically, all you need to is to be able to sign a message with it — either with native Ethereum signature, or via [EIP1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md) in case of smart contracts. Learn more in the [developer guide](../dev/overview.md).
+To control an address programmatically, all you need to is to be able to sign a message with it — either with native
+Ethereum signature, or via [EIP1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md) in case of smart
+contracts. Learn more in the [developer guide](../dev/overview.md).
 
 ## What if my wallet is not supported or can't sign a message?
 
-Owners of some Ethereum addresses cannot use zkSync directly for various reasons: 
+Owners of some Ethereum addresses cannot use zkSync directly for various reasons:
 
-- wallet not supported yet in the web interface; 
-- an address belongs to an exchange; 
-- an address belongs to a smart contract without [EIP1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md) support, e.g. Gnosis Safe).
+- wallet not supported yet in the web interface;
+- an address belongs to an exchange;
+- an address belongs to a smart contract without
+  [EIP1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md) support, e.g. Gnosis Safe).
 
-In such cases, you can always withdraw funds from an L2 zkSync account to the same address in L1. The protocol allows this because the security invariant is not violated: funds never change the owning hand. It requires that the account have never registered a zkSync public key before.
+In such cases, you can always withdraw funds from an L2 zkSync account to the same address in L1. The protocol allows
+this because the security invariant is not violated: funds never change the owning hand. It requires that the account
+have never registered a zkSync public key before.
 
-If you need to withdraw your funds from such an account, please shoot us your account address to **hello@matterlabs.dev** and we will initiate the withdrawal. In the future, this functionality will be fully automated.
+If you need to withdraw your funds from such an account, please shoot us your account address to
+**hello@matterlabs.dev** and we will initiate the withdrawal. In the future, this functionality will be fully automated.

--- a/docs/faq/wallets.md
+++ b/docs/faq/wallets.md
@@ -7,7 +7,7 @@
 Generally, you can safely send funds to any Ethereum address (even to exchanges and smart contracts). The owner of this
 address will always be able to claim the funds.
 
-The up-to-date list of the Etherum wallets that you can control from the zkSync web wallet can be found directly on
+The up-to-date list of the Ethereum wallets that you can control from the zkSync web wallet can be found directly on
 [its homepage](https://wallet.zksync.io).
 
 To control an address programmatically, all you need to is to be able to sign a message with it — either with native

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -25,4 +25,4 @@ zkSync website is currently undergoing planned maintenance. We'll be back up in 
 
 You can track the current maintenance status on [our twitter page](https://twitter.com/zksync).
 
-To not get bored in the meanwhile, try out the [demo on Rinkeby testnet](https://testnet.zksync.io).
+To not get bored in the meanwhile, try out the [demo on Rinkeby testnet](https://rinkeby.zksync.io).


### PR DESCRIPTION
Links to `testnet.zksync.io` are broken since the page no longer exists. 