### PR TITLE
fix typo of ethers.getDefaultProvider

### DIFF
--- a/docs/sdk/js/accounts.md
+++ b/docs/sdk/js/accounts.md
@@ -80,7 +80,7 @@ static async fromEthSigner(
 import * as zksync from 'zksync';
 import { ethers } from 'ethers';
 
-const ethersProvider = new ethers.getDefaultProvider('rinkeby');
+const ethersProvider = ethers.getDefaultProvider('rinkeby');
 const syncProvider = await zksync.getDefaultProvider('rinkeby');
 
 const ethWallet = ethers.Wallet.createRandom().connect(ethersProvider);
@@ -119,7 +119,7 @@ without them, such as Deposit, Emergency exit and reading the account state.
 import * as zksync from 'zksync';
 import { ethers } from 'ethers';
 
-const ethersProvider = new ethers.getDefaultProvider('rinkeby');
+const ethersProvider = ethers.getDefaultProvider('rinkeby');
 const syncProvider = await zksync.getDefaultProvider('rinkeby');
 
 const ethWallet = ethers.Wallet.createRandom().connect(ethersProvider);

--- a/docs/sdk/js/providers.md
+++ b/docs/sdk/js/providers.md
@@ -581,7 +581,7 @@ constructor(
 import * as zksync from 'zksync';
 import { ethers } from 'ethers';
 
-const ethersProvider = new ethers.getDefaultProvider('rinkeby');
+const ethersProvider = ethers.getDefaultProvider('rinkeby');
 const syncHttpProvider = await zksync.getDefaultProvider('rinkeby');
 
 const ethProxy = new zksync.ETHProxy(ethersProvider, syncHttpProvider.contractAddress);
@@ -611,7 +611,7 @@ async resolveTokenId(token: TokenAddress): Promise<number>;
 import * as zksync from 'zksync';
 import { ethers } from 'ethers';
 
-const ethersProvider = new ethers.getDefaultProvider('rinkeby');
+const ethersProvider = ethers.getDefaultProvider('rinkeby');
 const syncProvider = await zksync.getDefaultProvider('rinkeby');
 const ethProxy = new zksync.ETHProxy(ethersProvider, syncProvider.contractAddress);
 

--- a/docs/sdk/js/tutorial.md
+++ b/docs/sdk/js/tutorial.md
@@ -47,7 +47,7 @@ Most operations require some read-only access to the Ethereum network. We use `e
 Ethereum.
 
 ```typescript
-const ethersProvider = new ethers.getDefaultProvider('rinkeby');
+const ethersProvider = ethers.getDefaultProvider('rinkeby');
 ```
 
 ## Creating a Wallet


### PR DESCRIPTION
`new` is not needed because `ethers.getDefaultProvider` returns the class instants.

ref: https://docs.ethers.io/ethers.js/v5-beta/api-providers.html#connecting-to-ethereum