### PR TITLE
Fix Typo in Developer Docs

### DIFF
--- a/docs/dev/contracts/README.md
+++ b/docs/dev/contracts/README.md
@@ -85,7 +85,7 @@ likely be prohibited and should be omitted in order to keep the code compatible:
 
 As a little extra, we are working on a Solidity-to-Zinc transpiler to simplify the migration process.
 
-## Choosig the framework
+## Choosing the framework
 
 <table>
   <tr>


### PR DESCRIPTION
This fixes a typo in the contract developer docs.