### PR TITLE
NFT Docs 2

### DIFF
--- a/docs/api/sdk/js/nfts.md
+++ b/docs/api/sdk/js/nfts.md
@@ -1,6 +1,6 @@
 # NFTs
 
-NFTs are currently in testnet on the ropsten-beta and rinkeby-beta zkSync networks. This API reference provides descriptions for all functions regarding NFTs in zkSync 1.x. Currently it includes minting and transferring NFTs. Documentation for functions regarding withdrawals are coming very soon! Please start by reading our [high level overview](https://zksync.io/dev/nfts/).
+NFTs are currently in testnet on the ropsten-beta and rinkeby-beta zkSync networks. This API reference provides descriptions for all functions regarding NFTs in zkSync 1.x. Currently it includes minting and transferring NFTs. Documentation for functions regarding withdrawals is coming very soon! Please start by reading our [high level overview](https://zksync.io/dev/nfts/).
 
 - [Connecting to Rinkeby-beta testnet](https://zksync.io/api/sdk/js/nfts.html#connect-to-the-rinkeby-beta-testnet)
 - [Mint NFT](https://zksync.io/api/sdk/js/nfts.html#mint-nft)

--- a/docs/api/sdk/js/nfts.md
+++ b/docs/api/sdk/js/nfts.md
@@ -1,45 +1,23 @@
 # NFTs
 
-NFTs are currently in testnet on the ropsten-beta and rinkeby-beta zkSync networks. Please start by reading our [high level overview](https://zksync.io/dev/nfts/). This guide demonstrates how to mint and transfer NFTs. Withdrawals are coming very soon! 
+NFTs are currently in testnet on the ropsten-beta and rinkeby-beta zkSync networks. This API reference provides descriptions for all functions regarding NFTs in zkSync 1.x. Currently it includes minting and transferring NFTs. Documentation for functions regarding withdrawals are coming very soon! Please start by reading our [high level overview](https://zksync.io/dev/nfts/).
 
-## Setup
+- [Connecting to Rinkeby-beta testnet](https://zksync.io/api/sdk/js/nfts.html#connect-to-the-rinkeby-beta-testnet)
+- [Mint NFT](https://zksync.io/api/sdk/js/nfts.html#mint-nft)
+- [Transfer NFT](https://zksync.io/api/sdk/js/nfts.html#transfer-nft)
+- [Utility Functions](https://zksync.io/api/sdk/js/nfts.html#utility-functions)
+    - [Calculate Transaction Fee](https://zksync.io/api/sdk/js/nfts.html#calculate-transaction-fee)
+    - [View NFT](https://zksync.io/api/sdk/js/nfts.html#view-nft)
+    - [Get NFT](https://zksync.io/api/sdk/js/nfts.html#get-nft)
+    - [Get a receipt](https://zksync.io/api/sdk/js/nfts.html#get-a-receipt)
 
-Please read our [Getting Started](https://zksync.io/api/sdk/js/tutorial.html#getting-started) guide before beginning this tutorial. 
-### Install the zkSync@beta library
-
-```bash
-yarn add zksync@beta
-```
-
-### Connect to the Rinkeby-beta testnet
+## Connect to the Rinkeby-beta testnet
 
 ```typescript
 const syncProvider = await zksync.getDefaultProvider("rinkeby-beta");
 ```
 
 ## Mint NFT
-
-### Calculate Transaction Fee
-
-To calculate the transaction fee for minting an NFT, you can use the `getTransactionFee` method from the `Provider` class.
-
-> Signature
-
-```typescript
-async getTransactionFee(
-    txType: 'Withdraw' | 'Transfer' | 'FastWithdraw' | 'MintNFT' | ChangePubKeyFee | LegacyChangePubKeyFee,
-    address: Address,
-    tokenLike: TokenLike
-): Promise<Fee>
-```
-
-Example: 
-
-```typescript
-const { totalFee: fee } = await syncProvider.getTransactionFee("MintNFT", syncWallet.address(), feeToken);
-```
-
-### Mint the NFT
 
 You can mint an NFT by calling the `mintNFT` function from the `Wallet` class, now available in the zksync@beta version.
 
@@ -62,7 +40,6 @@ async mintNFT(mintNft: {
 | feeToken    | name of token in which fee is to be paid (typically ETH)                                            |
 | fee         | transaction fee                                                                                     |
 
-
 Example: 
 
 ```typescript
@@ -75,41 +52,11 @@ const nft = await syncWallet.mintNFT({
 });
 ```
 
-### Get a Receipt
-
-If you would like, you can also get a receipt for the minted NFT.
-
-```typescript
-const receipt = await nft.awaitReceipt();
-```
-
-### View an NFT
-
 After an NFT is minted, it can be in two states: committed and verified. An NFT is committed if it has been included in a rollup block, and verified when a zero knowledge proof has been generated for that block and the root hash of the rollup block has been included in the smart contract on Ethereum mainnet.
-
-To view an account's NFTs:
-
-```typescript
-// Get state of account
-const state = await syncProvider.getAccountState('<account-address>');
-// View committed NFTs
-console.log(state.committed.nfts);
-// View verified NFTs
-console.log(state.verified.nfts);
-```
-
-You may also find the `getNFT` function from the `Wallet` class useful.
-
-> Signature
-
-```typescript
-async getNFT(tokenId: number, type: 'committed' | 'verified' = 'committed'): Promise<NFT>
-```
 
 ## Transfer NFT
 
 An NFT can only be transferred after the block with it's mint transaction is verified. This means the newly minted NFT may have to wait a few hours before it can be transferred. This only applies to the first transfer; all following transfers can be completed with no restrictions.
-
 
 You can transfer an NFT by calling the `syncTransferNFT` function:
 
@@ -143,9 +90,60 @@ const handles = await sender.syncTransferNFT({
 });
 ```
 
+## Utility Functions
+
+### Calculate Transaction Fee
+
+To calculate the transaction fee for minting an NFT, the `getTransactionFee` method from the `Provider` class now supports transaction type `'MintNFT'`.
+
+> Signature
+
+```typescript
+async getTransactionFee(
+    txType: 'Withdraw' | 'Transfer' | 'FastWithdraw' | 'MintNFT' | ChangePubKeyFee | LegacyChangePubKeyFee,
+    address: Address,
+    tokenLike: TokenLike
+): Promise<Fee>
+```
+
+Example: 
+
+```typescript
+const { totalFee: fee } = await syncProvider.getTransactionFee("MintNFT", syncWallet.address(), feeToken);
+```
+
+### View an NFT
+
+To view an account's NFTs:
+
+```typescript
+// Get state of account
+const state = await syncProvider.getAccountState('<account-address>');
+// View committed NFTs
+console.log(state.committed.nfts);
+// View verified NFTs
+console.log(state.verified.nfts);
+```
+
+### Get an NFT
+
+You may also find the `getNFT` function from the `Wallet` class useful.
+
+> Signature
+
+```typescript
+async getNFT(tokenId: number, type: 'committed' | 'verified' = 'committed'): Promise<NFT>
+```
+
 ### Get a Receipt
 
-If you would like, you can also get a receipt for the transfer.
+To get a receipt for a minted NFT:
+
+```typescript
+const receipt = await nft.awaitReceipt();
+```
+
+To get a receipt for a transfer:
 
 ```typescript
 const receipt = await handles[0].awaitReceipt();

--- a/docs/api/sdk/js/nfts.md
+++ b/docs/api/sdk/js/nfts.md
@@ -140,11 +140,17 @@ async getNFT(tokenId: number, type: 'committed' | 'verified' = 'committed'): Pro
 To get a receipt for a minted NFT:
 
 ```typescript
+// mint nft
+const nft = await wallet.mintNFT({...});
+// get receipt
 const receipt = await nft.awaitReceipt();
 ```
 
 To get a receipt for a transfer:
 
 ```typescript
+// transfer nft
+const handles = await sender.syncTransferNFT({...});
+// get receipt
 const receipt = await handles[0].awaitReceipt();
 ```

--- a/docs/api/sdk/js/nfts.md
+++ b/docs/api/sdk/js/nfts.md
@@ -79,7 +79,7 @@ async syncTransferNFT(transfer: {
 | token    | address of the NFT                                       |
 | fee      | transaction fee                                          |
 
-The `syncTransferNFT` function works as a batched transaction under the hood, so it will return an array of transactions where the first handle is the fee and the second is the NFT transfer itself.  
+The `syncTransferNFT` function works as a batched transaction under the hood, so it will return an array of transactions where the first handle is the NFT transfer and the second is the fee.  
 
 ```typescript
 const handles = await sender.syncTransferNFT({

--- a/docs/dev/nfts.md
+++ b/docs/dev/nfts.md
@@ -1,5 +1,34 @@
 # NFTs in zkSync 1.x
+
+Support for NFTs on zkSync 1.x is here! Functions include minting, transferring, and atomically swapping NFTs. Users will also be able to withdraw NFTs to Layer 1.
+
+Functionality is currently in testnet on Rinkey-beta and Ropsten-beta.
+
+This page demonstrates how NFTs are implemented in zkSync 1.x and provides a tutorial for you to integrate NFTs into your project. 
+
+- [What's Live](https://zksync.io/dev/nfts.html#whats-live)
+- [Overview](https://zksync.io/dev/nfts.html#overview)
+- [Setup](https://zksync.io/dev/nfts.html#setup)
+- [Mint](https://zksync.io/dev/nfts.html#minting)
+- [Transfer](https://zksync.io/dev/nfts.html#)
+- [Withdrawal and Full Exit](https://zksync.io/dev/nfts.html#)
+
+## What's Live
+
+Functions currently available on Rinkeby-beta and Ropsten-beta testnet: 
+
+[x] Minting
+
+[x] Transferring
+
+[ ] Swapping
+
+[ ] Withdrawal to L1
+
+Swapping and withdrawals are coming soon!
+
 ## Overview
+
 NFT addresses will encode NFT content and metadata as follows: 
 
 ```typescript
@@ -13,9 +42,25 @@ This cryptographically ensures two invariants:
 
 NOTICE: In zkSync 1.x, multiple NFTs can be minted with the same content hash. 
 
-You can currently try out minting and transferring NFTs with our [SDK](https://zksync.io/api/sdk/js/nfts.html) on Rinkeby testnet.
+## Setup
 
-## Minting
+Please read our [Getting Started](https://zksync.io/api/sdk/js/tutorial.html#getting-started) guide before beginning this tutorial. 
+
+### Install the zkSync@beta library
+
+```bash
+yarn add zksync@beta
+```
+
+### Connect to the Rinkeby-beta testnet
+
+For this tutorial, let's connect to the Rinkeby-beta testnet. You can also use Ropsten-beta.
+
+```typescript
+const syncProvider = await zksync.getDefaultProvider("rinkeby-beta");
+```
+
+## Mint
 
 To mint an NFT, we will introduce a new opcode `MINT_NFT` with arguments:
 
@@ -47,10 +92,141 @@ CreatorAccount[SPECIAL_NFT_TOKEN] += 1
 
 zkSync servers will maintain a mapping of NFT token addresses to token IDs.
 
+### Calculate Transaction Fee
+
+To calculate the transaction fee for minting an NFT, you can use the `getTransactionFee` method from the `Provider` class.
+
+> Signature
+
+```typescript
+async getTransactionFee(
+    txType: 'Withdraw' | 'Transfer' | 'FastWithdraw' | 'MintNFT' | ChangePubKeyFee | LegacyChangePubKeyFee,
+    address: Address,
+    tokenLike: TokenLike
+): Promise<Fee>
+```
+
+Example: 
+
+```typescript
+const { totalFee: fee } = await syncProvider.getTransactionFee("MintNFT", syncWallet.address(), feeToken);
+```
+
+### Mint the NFT
+
+You can mint an NFT by calling the `mintNFT` function from the `Wallet` class, now available in the zksync@beta version.
+
+> Signature
+
+```typescript
+async mintNFT(mintNft: {
+    recipient: string;
+    contentHash: string;
+    feeToken: TokenLike;
+    fee?: BigNumberish;
+    nonce?: Nonce;
+}): Promise<Transaction>
+```
+
+| Name        | Description                                                                                         |
+| ----------- | --------------------------------------------------------------------------------------------------- |
+| recipient   | the recipient address represented as a hex string                                                   |
+| contentHash | the unique identifier of the NFT represented as a 32-byte hex string (e.g. IPFS content identifier) |
+| feeToken    | name of token in which fee is to be paid (typically ETH)                                            |
+| fee         | transaction fee                                                                                     |
+
+
+Example: 
+
+```typescript
+const contentHash = "0xbd7289936758c562235a3a42ba2c4a56cbb23a263bb8f8d27aead80d74d9d996"
+const nft = await syncWallet.mintNFT({
+    recipient: syncWallet.address(),
+    contentHash,
+    feeToken: "ETH",
+    fee,
+});
+```
+
+### Get a Receipt
+
+If you would like, you can also get a receipt for the minted NFT.
+
+```typescript
+const receipt = await nft.awaitReceipt();
+```
+
+### View the NFT
+
+After an NFT is minted, it can be in two states: committed and verified. An NFT is committed if it has been included in a rollup block, and verified when a zero knowledge proof has been generated for that block and the root hash of the rollup block has been included in the smart contract on Ethereum mainnet.
+
+To view an account's NFTs:
+
+```typescript
+// Get state of account
+const state = await syncProvider.getAccountState('<account-address>');
+// View committed NFTs
+console.log(state.committed.nfts);
+// View verified NFTs
+console.log(state.verified.nfts);
+```
+
+You may also find the `getNFT` function from the `Wallet` class useful.
+
+> Signature
+
+```typescript
+async getNFT(tokenId: number, type: 'committed' | 'verified' = 'committed'): Promise<NFT>
+```
+
 ## Transfer
 Users can transfer NFTs to existing accounts and transfer to addresses that have not yet registered a zkSync account. `TRANSFER` and `TRANSFER_TO_NEW` opcodes will work the same. 
 
-## Withdrawals and FullExits (Trustless Withdrawal)
+An NFT can only be transferred after the block with it's mint transaction is verified. This means the newly minted NFT may have to wait a few hours before it can be transferred. This only applies to the first transfer; all following transfers can be completed with no restrictions.
+
+
+You can transfer an NFT by calling the `syncTransferNFT` function:
+
+```typescript
+async syncTransferNFT(transfer: {
+    to: Address;
+    token: NFT;
+    feeToken: TokenLike;
+    fee?: BigNumberish;
+    nonce?: Nonce;
+    validFrom?: number;
+    validUntil?: number;
+}): Promise<Transaction[]>
+```
+
+| Name     | Description                                              |
+| -------- | -------------------------------------------------------- |
+| to       | the recipient address represented as a hex string        |
+| feeToken | name of token in which fee is to be paid (typically ETH) |
+| token    | address of the NFT                                       |
+| fee      | transaction fee                                          |
+
+The `syncTransferNFT` function works as a batched transaction under the hood, so it will return an array of transactions where the first handle is the fee and the second is the NFT transfer itself.  
+
+```typescript
+const handles = await sender.syncTransferNFT({
+  to: receiver.address(),
+  feeToken,
+  token: nft,
+  fee,
+});
+```
+
+### Get a Receipt
+
+If you would like, you can also get a receipt for the transfer.
+
+```typescript
+const receipt = await handles[0].awaitReceipt();
+```
+## Withdrawal and Full Exit
+
+A [Full Exit](https://zksync.io/dev/payments/basic.html#flow) is a trustless withdrawal: a Layer 1 contract call provided in the rare case your transaction is being censored. 
 
 Withdrawals to L1 will require 3 actors:
 
@@ -58,7 +234,7 @@ Withdrawals to L1 will require 3 actors:
 - Creator: user which *mints* NFT on L2
 - NFTOwner: user which *owns* NFT on L2
 
-Withdrawing is currently not available in testnet, but it will be during the mainnet launch.
+Withdrawing is not available in testnet yet. The general architecture is detailed below.
 
 ### Factory and zkSync Smart Contract Interaction
 

--- a/docs/dev/nfts.md
+++ b/docs/dev/nfts.md
@@ -206,7 +206,7 @@ async syncTransferNFT(transfer: {
 | token    | address of the NFT                                       |
 | fee      | transaction fee                                          |
 
-The `syncTransferNFT` function works as a batched transaction under the hood, so it will return an array of transactions where the first handle is the fee and the second is the NFT transfer itself.  
+The `syncTransferNFT` function works as a batched transaction under the hood, so it will return an array of transactions where the first handle is the NFT transfer and the second is the fee.  
 
 ```typescript
 const handles = await sender.syncTransferNFT({

--- a/docs/dev/nfts.md
+++ b/docs/dev/nfts.md
@@ -150,7 +150,7 @@ const nft = await syncWallet.mintNFT({
 
 ### Get a Receipt
 
-If you would like, you can also get a receipt for the minted NFT.
+To get a receipt for the minted NFT:
 
 ```typescript
 const receipt = await nft.awaitReceipt();
@@ -219,7 +219,7 @@ const handles = await sender.syncTransferNFT({
 
 ### Get a Receipt
 
-If you would like, you can also get a receipt for the transfer.
+To get a receipt for the transfer:
 
 ```typescript
 const receipt = await handles[0].awaitReceipt();


### PR DESCRIPTION
This PR: 
- strips API reference to barebones explanation of relevant functions
- moves tutorial from API ref to developer documentation
- adds introduction to dev docs
- adds outlines

Nothing at the concept level was added, so all information remains accurate to the original PR. I simply duplicated and shifted things around.