### PR TITLE
docs: Add Dune Dashboard to User Docs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -42,6 +42,10 @@ module.exports = {
         link: "/zkevm/",
       },
       {
+        text: "Stats Dashboard",
+        link: "/dashboard/",
+      },
+      {
         text: "Contact and Media",
         link: "/contact.html",
       },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -42,10 +42,6 @@ module.exports = {
         link: "/zkevm/",
       },
       {
-        text: "Stats Dashboard",
-        link: "/dashboard/",
-      },
-      {
         text: "Contact and Media",
         link: "/contact.html",
       },
@@ -127,6 +123,12 @@ module.exports = {
         {
           title: "Roadmap", // required
           path: "/faq/roadmap", // optional, which should be a absolute path.
+          collapsable: true, // optional, defaults to true
+          sidebarDepth: 1, // optional, defaults to 1
+        },
+        {
+          title: "Dune Dashboard", // required
+          path: "/faq/dashboard", // optional, which should be a absolute path.
           collapsable: true, // optional, defaults to true
           sidebarDepth: 1, // optional, defaults to 1
         },

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -52,7 +52,7 @@
 div#root {
   position: absolute;
   width: 100%;
-  left: -5px;
+  left:  330px;
   height: 100%;
 }
 
@@ -61,5 +61,6 @@ div#root > iframe {
   display: block;
   width: 100%;
   height: 100%;
+  background-color: #FFFFFF
   border: none;
 }

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -46,3 +46,20 @@
     background-color: darken(#fff, 5%);
     }
 }
+
+
+/* dune iframe */
+div#root {
+  position: absolute;
+  width: 100%;
+  left: -5px;
+  height: 100%;
+}
+
+/* dune iframe */
+div#root > iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: none;
+}

--- a/docs/dashboard/README.md
+++ b/docs/dashboard/README.md
@@ -1,0 +1,4 @@
+<div id="root">
+	<iframe src="https://dune.xyz/kylin/Zksync" scrolling="auto"></iframe>
+</div>
+

--- a/docs/faq/dashboard.md
+++ b/docs/faq/dashboard.md
@@ -1,3 +1,5 @@
+<div></div>
+
 <div id="root">
 	<iframe src="https://dune.xyz/kylin/Zksync" scrolling="auto"></iframe>
 </div>


### PR DESCRIPTION
## Description
Add Dune dashboard embed into user docs. The zkSync stats and tvl page created on Dune.
 
## Motivation and Context
Looks great, it is nice to have in an accessible place for one to see when looking at docs.

## How Has This Been Tested?
Locally on my computer

## Screen shots
![dunepr1](https://user-images.githubusercontent.com/61128114/147524689-28eee076-deb3-43b2-a514-45f123584172.png)
![dashboard](https://user-images.githubusercontent.com/61128114/147524698-0be38a28-46aa-41f8-9305-91bc3c8d078a.png)

## Types of changes
 [ na] Bug fix (non-breaking change which fixes an issue)
[ na] New feature (non-breaking change which adds functionality)
[ na]  Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
[ X] My code follows the code style of this project.
[ na] My change requires a change to the documentation.
[X ] I have updated the documentation accordingly.
[X ] I have read the CONTRIBUTING document.
[ na] I have added tests to cover my changes.
[ na] All new and existing tests passed.

## Notes
I believe premium Dune would make the dashboard slightly less cluttered at the top fyi.