### PR TITLE
fix: service pages (page-lockers) excluded from google-parsed links

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -19,7 +19,6 @@ module.exports = {
     sitemap: {
       hostname: "https://zksync.io",
     },
-    "@vuepress/html-redirect": {},
   },
   themeConfig: {
     logo: "/LogotypeLight.svg",
@@ -257,7 +256,7 @@ module.exports = {
     ["script", { src: "/__/firebase/7.13.2/firebase-app.js", defer: true }, ""],
     ["script", { src: "/__/firebase/7.13.2/firebase-analytics.js", defer: true }, ""],
     ["script", { src: "/__/firebase/init.js", defer: true }, ""],
-    //Hack: Make clicking on the logo go to home url
+    //Hack: redirects the user to the zksync.io index page when clicking on the logo
     [
       "script",
       {},
@@ -290,13 +289,13 @@ module.exports = {
         requestAnimationFrame(function() {
           if (location.hash) {
             const element = document.getElementById(location.hash.slice(1))
-      
+
             if (element) {
               element.scrollIntoView();
             }
           }
         });
-      }      
+      }
       `,
     ],
   ],

--- a/docs/.vuepress/redirects
+++ b/docs/.vuepress/redirects
@@ -1,1 +1,0 @@
-/faq/ /userdocs/

--- a/firebase.json
+++ b/firebase.json
@@ -15,6 +15,16 @@
         "type": 301
       },
       {
+        "source": "/faq/",
+        "destination": "/userdocs/",
+        "type": 301
+      },
+      {
+        "source": "/faq.html",
+        "destination": "/userdocs/",
+        "type": 301
+      },
+      {
         "source": "/dev/bug-bounty",
         "destination": "/dev/security/bug-bounty.html",
         "type": 301

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "@types/babel__preset-env": "^7",
     "@types/hammerjs": "^2.0.39",
     "@typescript-eslint/parser": "^4.15.1",
-    "@vuepress/plugin-html-redirect": "^0.1.4",
     "check-md": "^1.0.1",
     "cspell": "^4.1.5",
     "dotenv": "8.2.0",

--- a/src/static/robots.txt
+++ b/src/static/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+
+# Example 3: Block all but AdsBot crawlers
+User-agent: *
+Disallow: /service/

--- a/yarn.lock
+++ b/yarn.lock
@@ -4372,13 +4372,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-html-redirect@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "@vuepress/plugin-html-redirect@npm:0.1.4"
-  checksum: 6f496193ab1ebbd91666802bfd872904457d536166d830ff270331788a7ff7a08efd88f863aed8bda2bf3fc4d2bf593b21f142f8445a5a788c622c20048b1fbb
-  languageName: node
-  linkType: hard
-
 "@vuepress/plugin-last-updated@npm:1.9.5":
   version: 1.9.5
   resolution: "@vuepress/plugin-last-updated@npm:1.9.5"
@@ -21744,7 +21737,6 @@ __metadata:
     "@typescript-eslint/parser": ^4.15.1
     "@vue/cli-service": ^4.5.11
     "@vuepress/core": ^1.8.2
-    "@vuepress/plugin-html-redirect": ^0.1.4
     aos: ^2.3.4
     check-md: ^1.0.1
     cspell: ^4.1.5


### PR DESCRIPTION
- solved with the robots.txt
- `docs/.vuepress/redirects` & vuepress-redirect-plugin dropped as redundant
- redirect rule from `docs/.vuepress/redirects` moved to the firebase.json

Closes ZKF-1497