### PR TITLE
docs: LearnByWatching - Duplicate links

### DIFF
--- a/docs/userdocs/learnbywatching/README.md
+++ b/docs/userdocs/learnbywatching/README.md
@@ -4,5 +4,4 @@ Click on the links below for a playlist of curated videos on each topic.
 
 - [zkRollups](https://www.youtube.com/watch?v=hcLoSQmvhfY&list=PL-Bw34ynlUONLcuwOdaG7A06YQrGEns4s)
 - [zkSync 1.0](https://www.youtube.com/watch?v=el-9YYGN1nw&list=PL-Bw34ynlUONlnXdkm608shHry8hrYlex)
-- [zkSync 2.0](https://www.youtube.com/watch?v=el-9YYGN1nw&list=PL-Bw34ynlUOP3r0zFeM48JnNZyun2E6Bt)
 - [zkPorter](https://www.youtube.com/watch?v=zknVgruhjnU&list=PL-Bw34ynlUOPdA6YsTOc_8xCa_DG45tF6)


### PR DESCRIPTION
This third link "zkSync 2.0" is identical to the second "zkSync 1.0", recommend removing