### PR TITLE
chore: update docs links

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -7,7 +7,7 @@ concurrency:
 on: pull_request
 jobs:
   build_and_preview:
-    if: ${{ github.event.repository.full_name == github.repository }} && ${{ github.repository }} == "matter-labs/zksync-docs" || ${{ github.event.pull_request.base.repo.full_name == github.repository }}
+    if: ${{ github.event.repository.full_name == github.repository }} && ${{ github.repository }} == "matter-labs/zksync-lite-docs" || ${{ github.event.pull_request.base.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     environment: dev
     steps:
@@ -19,7 +19,7 @@ jobs:
           yarn install
 
       - name: "Enable yarn cache"
-        uses: c-hive/gha-yarn-cache@v2  # using cache
+        uses: c-hive/gha-yarn-cache@v2 # using cache
 
       - name: "Setup node@14"
         uses: actions/setup-node@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,123 +1,123 @@
 t
-# [2.8.0](https://github.com/matter-labs/zksync-docs/compare/2.7.1...2.8.0) (2022-02-15)
+# [2.8.0](https://github.com/matter-labs/zksync-lite-docs/compare/2.7.1...2.8.0) (2022-02-15)
 
 
 ### Features
 
-* multiple changes ([#232](https://github.com/matter-labs/zksync-docs/issues/232)) ([16324a9](https://github.com/matter-labs/zksync-docs/commit/16324a9e4a0918a3f701fc3aff49f30c0b99f78c))
+* multiple changes ([#232](https://github.com/matter-labs/zksync-lite-docs/issues/232)) ([16324a9](https://github.com/matter-labs/zksync-lite-docs/commit/16324a9e4a0918a3f701fc3aff49f30c0b99f78c))
 
-## [2.7.1](https://github.com/matter-labs/zksync-docs/compare/2.7.0...2.7.1) (2022-02-14)
+## [2.7.1](https://github.com/matter-labs/zksync-lite-docs/compare/2.7.0...2.7.1) (2022-02-14)
 
 
 ### Bug Fixes
 
-* first anchor scroll ([#91](https://github.com/matter-labs/zksync-docs/issues/91)) ([81e3d80](https://github.com/matter-labs/zksync-docs/commit/81e3d808c62373e01d22fea297e05e4cb98ae939))
+* first anchor scroll ([#91](https://github.com/matter-labs/zksync-lite-docs/issues/91)) ([81e3d80](https://github.com/matter-labs/zksync-lite-docs/commit/81e3d808c62373e01d22fea297e05e4cb98ae939))
 
-# [2.7.0](https://github.com/matter-labs/zksync-docs/compare/2.6.0...2.7.0) (2022-02-14)
+# [2.7.0](https://github.com/matter-labs/zksync-lite-docs/compare/2.6.0...2.7.0) (2022-02-14)
 
 
 ### Features
 
-* zksync.io tools menu changed ([#226](https://github.com/matter-labs/zksync-docs/issues/226)) ([75603b0](https://github.com/matter-labs/zksync-docs/commit/75603b062c34f6cf7a68382838642d99298fd92d))
+* zksync.io tools menu changed ([#226](https://github.com/matter-labs/zksync-lite-docs/issues/226)) ([75603b0](https://github.com/matter-labs/zksync-lite-docs/commit/75603b062c34f6cf7a68382838642d99298fd92d))
 
-# [2.6.0](https://github.com/matter-labs/zksync-docs/compare/2.5.3...2.6.0) (2022-01-28)
-
-
-### Features
-
-* service pages (page-lockers) excluded from google-parsed links ([#225](https://github.com/matter-labs/zksync-docs/issues/225)) ([b2c767f](https://github.com/matter-labs/zksync-docs/commit/b2c767ff69c274520c6add828da2667930ad1161))
-
-## [2.5.3](https://github.com/matter-labs/zksync-docs/compare/2.5.2...2.5.3) (2022-01-27)
-
-
-### Bug Fixes
-
-* redirects for moved links ([#223](https://github.com/matter-labs/zksync-docs/issues/223)) ([ce00bfe](https://github.com/matter-labs/zksync-docs/commit/ce00bfe5b469e580d2c701e30dca863e21b09d7b))
-
-## [2.5.2](https://github.com/matter-labs/zksync-docs/compare/2.5.1...2.5.2) (2022-01-20)
-
-
-### Bug Fixes
-
-* tutorials page crashing the page ([#220](https://github.com/matter-labs/zksync-docs/issues/220)) ([24d3786](https://github.com/matter-labs/zksync-docs/commit/24d3786111d03f71e692b4be332aa80d6f224a5d))
-
-## [2.5.1](https://github.com/matter-labs/zksync-docs/compare/2.5.0...2.5.1) (2022-01-19)
-
-
-### Bug Fixes
-
-* faq crashing docs ([#219](https://github.com/matter-labs/zksync-docs/issues/219)) ([0d244f4](https://github.com/matter-labs/zksync-docs/commit/0d244f425c2921dfa15fe8d3338498ba4e1ab2aa))
-
-# [2.5.0](https://github.com/matter-labs/zksync-docs/compare/2.4.1...2.5.0) (2022-01-19)
+# [2.6.0](https://github.com/matter-labs/zksync-lite-docs/compare/2.5.3...2.6.0) (2022-01-28)
 
 
 ### Features
 
-* Button changes + new styling added ([#205](https://github.com/matter-labs/zksync-docs/issues/205)) ([d614f26](https://github.com/matter-labs/zksync-docs/commit/d614f26deacc40b3e01181a7c236b14fac79d031))
+* service pages (page-lockers) excluded from google-parsed links ([#225](https://github.com/matter-labs/zksync-lite-docs/issues/225)) ([b2c767f](https://github.com/matter-labs/zksync-lite-docs/commit/b2c767ff69c274520c6add828da2667930ad1161))
 
-## [2.4.1](https://github.com/matter-labs/zksync-docs/compare/2.4.0...2.4.1) (2022-01-17)
-
-
-### Bug Fixes
-
-* Corrected typo ([#212](https://github.com/matter-labs/zksync-docs/issues/212)) ([c2c6e90](https://github.com/matter-labs/zksync-docs/commit/c2c6e90439a89936c6530f0d90b8dee7f951480f))
-
-# [2.4.0](https://github.com/matter-labs/zksync-docs/compare/2.3.0...2.4.0) (2022-01-13)
-
-
-### Features
-
-* configs update & new security information ([#216](https://github.com/matter-labs/zksync-docs/issues/216)) ([0e25f5e](https://github.com/matter-labs/zksync-docs/commit/0e25f5ebd1da7e64f0176f0e73c02982e73bbb7f))
-
-# [2.3.0](https://github.com/matter-labs/zksync-docs/compare/2.2.0...2.3.0) (2022-01-13)
+## [2.5.3](https://github.com/matter-labs/zksync-lite-docs/compare/2.5.2...2.5.3) (2022-01-27)
 
 
 ### Bug Fixes
 
-* add l2fees image ([ee5b013](https://github.com/matter-labs/zksync-docs/commit/ee5b0136b35e596a26c6b7e6113255be2f0bc902))
-* add meta tags ([ed605f5](https://github.com/matter-labs/zksync-docs/commit/ed605f5a4970ec1ff72253a44593de7e6c3366f3))
-* docs anchor ([96a109e](https://github.com/matter-labs/zksync-docs/commit/96a109ed5dbd1d4f2f1eac34b0234a641222d1ad))
-* **firebase:** fixing ci issues and yarn upgrade ([71afe5e](https://github.com/matter-labs/zksync-docs/commit/71afe5e01b1b96fc6cfd1a47441b1ebe450c5924))
-* navigation to zkEVM ([aae1fc4](https://github.com/matter-labs/zksync-docs/commit/aae1fc4f805b1af57676e69a39cb53b2dda2d181))
-* no hover effect for z-button ([530c92a](https://github.com/matter-labs/zksync-docs/commit/530c92a05c16d5bfe3228acf76c158bae2e65e5f))
-* remove out of gas link ([d80c8a1](https://github.com/matter-labs/zksync-docs/commit/d80c8a14c16710a52e0014f4a3f76eecca7ce469))
-* rename folder ([963341b](https://github.com/matter-labs/zksync-docs/commit/963341b315174012c35a989904945c58ead52614))
-* rename zkevm folder ([766dc81](https://github.com/matter-labs/zksync-docs/commit/766dc8193d848e2980e09ded593487f1b87c2e77))
-* reorganize into a single file ([97f92bb](https://github.com/matter-labs/zksync-docs/commit/97f92bb1dd8dbb1ad80532aa3a78f833bf644b01))
-* restructure zkEVM FAQ ([5a4bf95](https://github.com/matter-labs/zksync-docs/commit/5a4bf953efcc9110da0e36e5f1e4cc1f63929dfa))
-* restructure zkEVM FAQ ([9942163](https://github.com/matter-labs/zksync-docs/commit/99421632b7599d305ff60324acd07d06ee7d685a))
-* **scss:** unused imports removed ([fb92994](https://github.com/matter-labs/zksync-docs/commit/fb929947077d462a9b8091c9bfb8a5926dd3c270))
-* smaller submit button ([454371e](https://github.com/matter-labs/zksync-docs/commit/454371e2429213ea0256b734300b29736ea4aa03))
+* redirects for moved links ([#223](https://github.com/matter-labs/zksync-lite-docs/issues/223)) ([ce00bfe](https://github.com/matter-labs/zksync-lite-docs/commit/ce00bfe5b469e580d2c701e30dca863e21b09d7b))
+
+## [2.5.2](https://github.com/matter-labs/zksync-lite-docs/compare/2.5.1...2.5.2) (2022-01-20)
+
+
+### Bug Fixes
+
+* tutorials page crashing the page ([#220](https://github.com/matter-labs/zksync-lite-docs/issues/220)) ([24d3786](https://github.com/matter-labs/zksync-lite-docs/commit/24d3786111d03f71e692b4be332aa80d6f224a5d))
+
+## [2.5.1](https://github.com/matter-labs/zksync-lite-docs/compare/2.5.0...2.5.1) (2022-01-19)
+
+
+### Bug Fixes
+
+* faq crashing docs ([#219](https://github.com/matter-labs/zksync-lite-docs/issues/219)) ([0d244f4](https://github.com/matter-labs/zksync-lite-docs/commit/0d244f425c2921dfa15fe8d3338498ba4e1ab2aa))
+
+# [2.5.0](https://github.com/matter-labs/zksync-lite-docs/compare/2.4.1...2.5.0) (2022-01-19)
 
 
 ### Features
 
-* add zkevm section ([6f46ac9](https://github.com/matter-labs/zksync-docs/commit/6f46ac9d4fa547077dde23176e9ef9547279dbbb))
-* investors pages on mobile ([74632c3](https://github.com/matter-labs/zksync-docs/commit/74632c31e1b1baf6316097df37860bcdebcbf57f))
-* **partners:** logo replaced ([f56524d](https://github.com/matter-labs/zksync-docs/commit/f56524d7d2f7d6425c3c60dd41632a551f54c681))
-* rename faq route to userdocs + redirect ([#209](https://github.com/matter-labs/zksync-docs/issues/209)) ([4465745](https://github.com/matter-labs/zksync-docs/commit/44657458487d2bb6ef9f08f9e81e7d2ac001a88a))
-* **semantic-release:** semantic release added & husky reconfigured ([05f428f](https://github.com/matter-labs/zksync-docs/commit/05f428f9b173964ba1f17da64610901c95c8dd08))
-* **semantic-zk-ci:** configured full-featured semantic CI w/t lintin ([49910ae](https://github.com/matter-labs/zksync-docs/commit/49910ae3fa53f681b492f2f0f5b2bf178e30a77a))
-* **semantic-zk-ci:** configured full-featured semantic CI w/t linting ([6df126e](https://github.com/matter-labs/zksync-docs/commit/6df126e875af0eacf13e63e17639f42066957e50))
+* Button changes + new styling added ([#205](https://github.com/matter-labs/zksync-lite-docs/issues/205)) ([d614f26](https://github.com/matter-labs/zksync-lite-docs/commit/d614f26deacc40b3e01181a7c236b14fac79d031))
+
+## [2.4.1](https://github.com/matter-labs/zksync-lite-docs/compare/2.4.0...2.4.1) (2022-01-17)
+
+
+### Bug Fixes
+
+* Corrected typo ([#212](https://github.com/matter-labs/zksync-lite-docs/issues/212)) ([c2c6e90](https://github.com/matter-labs/zksync-lite-docs/commit/c2c6e90439a89936c6530f0d90b8dee7f951480f))
+
+# [2.4.0](https://github.com/matter-labs/zksync-lite-docs/compare/2.3.0...2.4.0) (2022-01-13)
+
+
+### Features
+
+* configs update & new security information ([#216](https://github.com/matter-labs/zksync-lite-docs/issues/216)) ([0e25f5e](https://github.com/matter-labs/zksync-lite-docs/commit/0e25f5ebd1da7e64f0176f0e73c02982e73bbb7f))
+
+# [2.3.0](https://github.com/matter-labs/zksync-lite-docs/compare/2.2.0...2.3.0) (2022-01-13)
+
+
+### Bug Fixes
+
+* add l2fees image ([ee5b013](https://github.com/matter-labs/zksync-lite-docs/commit/ee5b0136b35e596a26c6b7e6113255be2f0bc902))
+* add meta tags ([ed605f5](https://github.com/matter-labs/zksync-lite-docs/commit/ed605f5a4970ec1ff72253a44593de7e6c3366f3))
+* docs anchor ([96a109e](https://github.com/matter-labs/zksync-lite-docs/commit/96a109ed5dbd1d4f2f1eac34b0234a641222d1ad))
+* **firebase:** fixing ci issues and yarn upgrade ([71afe5e](https://github.com/matter-labs/zksync-lite-docs/commit/71afe5e01b1b96fc6cfd1a47441b1ebe450c5924))
+* navigation to zkEVM ([aae1fc4](https://github.com/matter-labs/zksync-lite-docs/commit/aae1fc4f805b1af57676e69a39cb53b2dda2d181))
+* no hover effect for z-button ([530c92a](https://github.com/matter-labs/zksync-lite-docs/commit/530c92a05c16d5bfe3228acf76c158bae2e65e5f))
+* remove out of gas link ([d80c8a1](https://github.com/matter-labs/zksync-lite-docs/commit/d80c8a14c16710a52e0014f4a3f76eecca7ce469))
+* rename folder ([963341b](https://github.com/matter-labs/zksync-lite-docs/commit/963341b315174012c35a989904945c58ead52614))
+* rename zkevm folder ([766dc81](https://github.com/matter-labs/zksync-lite-docs/commit/766dc8193d848e2980e09ded593487f1b87c2e77))
+* reorganize into a single file ([97f92bb](https://github.com/matter-labs/zksync-lite-docs/commit/97f92bb1dd8dbb1ad80532aa3a78f833bf644b01))
+* restructure zkEVM FAQ ([5a4bf95](https://github.com/matter-labs/zksync-lite-docs/commit/5a4bf953efcc9110da0e36e5f1e4cc1f63929dfa))
+* restructure zkEVM FAQ ([9942163](https://github.com/matter-labs/zksync-lite-docs/commit/99421632b7599d305ff60324acd07d06ee7d685a))
+* **scss:** unused imports removed ([fb92994](https://github.com/matter-labs/zksync-lite-docs/commit/fb929947077d462a9b8091c9bfb8a5926dd3c270))
+* smaller submit button ([454371e](https://github.com/matter-labs/zksync-lite-docs/commit/454371e2429213ea0256b734300b29736ea4aa03))
+
+
+### Features
+
+* add zkevm section ([6f46ac9](https://github.com/matter-labs/zksync-lite-docs/commit/6f46ac9d4fa547077dde23176e9ef9547279dbbb))
+* investors pages on mobile ([74632c3](https://github.com/matter-labs/zksync-lite-docs/commit/74632c31e1b1baf6316097df37860bcdebcbf57f))
+* **partners:** logo replaced ([f56524d](https://github.com/matter-labs/zksync-lite-docs/commit/f56524d7d2f7d6425c3c60dd41632a551f54c681))
+* rename faq route to userdocs + redirect ([#209](https://github.com/matter-labs/zksync-lite-docs/issues/209)) ([4465745](https://github.com/matter-labs/zksync-lite-docs/commit/44657458487d2bb6ef9f08f9e81e7d2ac001a88a))
+* **semantic-release:** semantic release added & husky reconfigured ([05f428f](https://github.com/matter-labs/zksync-lite-docs/commit/05f428f9b173964ba1f17da64610901c95c8dd08))
+* **semantic-zk-ci:** configured full-featured semantic CI w/t lintin ([49910ae](https://github.com/matter-labs/zksync-lite-docs/commit/49910ae3fa53f681b492f2f0f5b2bf178e30a77a))
+* **semantic-zk-ci:** configured full-featured semantic CI w/t linting ([6df126e](https://github.com/matter-labs/zksync-lite-docs/commit/6df126e875af0eacf13e63e17639f42066957e50))
 
 
 ### Performance Improvements
 
-* **seo:** sitemap added | Closes ZKF-1043 ([eb0453a](https://github.com/matter-labs/zksync-docs/commit/eb0453a7472d96fcc0285a60849b25239decff86))
+* **seo:** sitemap added | Closes ZKF-1043 ([eb0453a](https://github.com/matter-labs/zksync-lite-docs/commit/eb0453a7472d96fcc0285a60849b25239decff86))
 
 # Changelog
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [2.2.0](https://github.com/matter-labs/zksync-docs/compare/2.1.2...2.2.0) (2021-07-06)
+## [2.2.0](https://github.com/matter-labs/zksync-lite-docs/compare/2.1.2...2.2.0) (2021-07-06)
 
 
 ### Features
 
-* **content:** zkNft link added, zkMint link fixed & dropdown behaviour improved ([ab48f62](https://github.com/matter-labs/zksync-docs/commit/ab48f62737b5734f352814ef0756aac4b46eb49e))
-* **content:** zkNft link added, zkMint link fixed & dropdown behaviour improved & extra review from imToken added ([b0a9e57](https://github.com/matter-labs/zksync-docs/commit/b0a9e5754310a479b1d5e726972e3de8ee3625fd))
+* **content:** zkNft link added, zkMint link fixed & dropdown behaviour improved ([ab48f62](https://github.com/matter-labs/zksync-lite-docs/commit/ab48f62737b5734f352814ef0756aac4b46eb49e))
+* **content:** zkNft link added, zkMint link fixed & dropdown behaviour improved & extra review from imToken added ([b0a9e57](https://github.com/matter-labs/zksync-lite-docs/commit/b0a9e5754310a479b1d5e726972e3de8ee3625fd))
 
 
 ### Bug Fixes
 
-* **ci:** node-sass version downgraded ([59e991e](https://github.com/matter-labs/zksync-docs/commit/59e991ed24465baeb5962b861acae11f29a04c6c))
+* **ci:** node-sass version downgraded ([59e991e](https://github.com/matter-labs/zksync-lite-docs/commit/59e991ed24465baeb5962b861acae11f29a04c6c))

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# [zkSync Lite Docs](https://docs.zksync.io/) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/matter-labs/zksync-docs) ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/matter-labs/zksync-docs/Deploy%20production)
+# [zkSync Lite Docs](https://docs.lite.zksync.io/) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/matter-labs/zksync-lite-docs) ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/matter-labs/zksync-lite-docs/Deploy%20production)
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/matter-labs/zksync-docs/blob/master/LICENSE) [![npm version](https://img.shields.io/npm/v/zksync.svg?style=flat)](https://www.npmjs.com/package/zksync) [![Follow us!](https://img.shields.io/twitter/follow/zksync?color=%238C8DFC&label=Follow%20%40zkSync&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iNDMiIGhlaWdodD0iMjUiIHZpZXdCb3g9IjAgMCA0MyAyNSIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik00Mi42NTM5IDEyLjQ5MTVMMzAuODM3OCAwLjcxNjc0M1Y5LjM0TDE5LjEwNTUgMTcuOTczOUwzMC44Mzc4IDE3Ljk4MlYyNC4yNjYyTDQyLjY1MzkgMTIuNDkxNVoiIGZpbGw9IiM0RTUyOUEiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wLjk5ODA0NyAxMi40ODcyTDEyLjgxNDEgMjQuMjYxOVYxNS43MDhMMjQuNTQ2NSA3LjAwNDdMMTIuODE0MSA2Ljk5NjY0VjAuNzEyNDYzTDAuOTk4MDQ3IDEyLjQ4NzJaIiBmaWxsPSIjOEM4REZDIi8%2BCjwvc3ZnPgo%3D&style=flat)](https://twitter.com/zksync)
 
 
 ## zkSync Documentation for the v1 | [CHANGELOG](./CHANGELOG.md)
 
-This repository contains the zkSync documentation hosted at [docs.zksync.io](https://docs.zksync.io)
+This repository contains the zkSync documentation hosted at [docs.lite.zksync.io/](https://docs.lite.zksync.io/)
 
 ## Development
 
@@ -82,7 +82,7 @@ Configuration in `cspell.json`:
   "dictionaries": ["typescript", "zksync"],
   //
   "dictionaryDefinitions": [
-  { 
+  {
     "name": "zksync", "path": "./cspell-zksync.txt"
   }
 ]
@@ -94,10 +94,9 @@ Configuration in `cspell.json`:
 # zkSync Ecosystem
 
 - [**Start building with zkSync v2 🚀**](https://portal.zksync.io)
-- [Integration Docs](https://zksync.io/dev)
-- [Available API & protocols](https://zksync.io/api/)
+- [Integration Docs](https://docs.lite.zksync.io/dev)
+- [Available API & protocols](https://docs.lite.zksync.io/api/)
 - [zkWallet](https://lite.zksync.io/)
-- [zkMint](https://mint.zksync.dev/)
 - [Alternative Withdrawal](https://withdraw.zksync.io/)
 - [zkScan](https://zkscan.io/)
 - [’out-of-gas’ issue solver ](https://withdraw.zksync.io/)
@@ -105,7 +104,7 @@ Configuration in `cspell.json`:
 ---
 
 - [Matter Labs: creators of the zkSync](https://matter-labs.io)
-- [zkSync Lite Homepage](https://zksync.io)
+- [ZKsync  Homepage](https://zksync.io)
 
 ---
 > BTW, we're hiring: [See open positions](https://joinmatterlabs.com)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [zkSync Lite Docs](https://docs.lite.zksync.io/) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/matter-labs/zksync-lite-docs) ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/matter-labs/zksync-lite-docs/Deploy%20production)
 
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/matter-labs/zksync-docs/blob/master/LICENSE) [![npm version](https://img.shields.io/npm/v/zksync.svg?style=flat)](https://www.npmjs.com/package/zksync) [![Follow us!](https://img.shields.io/twitter/follow/zksync?color=%238C8DFC&label=Follow%20%40zkSync&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iNDMiIGhlaWdodD0iMjUiIHZpZXdCb3g9IjAgMCA0MyAyNSIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik00Mi42NTM5IDEyLjQ5MTVMMzAuODM3OCAwLjcxNjc0M1Y5LjM0TDE5LjEwNTUgMTcuOTczOUwzMC44Mzc4IDE3Ljk4MlYyNC4yNjYyTDQyLjY1MzkgMTIuNDkxNVoiIGZpbGw9IiM0RTUyOUEiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wLjk5ODA0NyAxMi40ODcyTDEyLjgxNDEgMjQuMjYxOVYxNS43MDhMMjQuNTQ2NSA3LjAwNDdMMTIuODE0MSA2Ljk5NjY0VjAuNzEyNDYzTDAuOTk4MDQ3IDEyLjQ4NzJaIiBmaWxsPSIjOEM4REZDIi8%2BCjwvc3ZnPgo%3D&style=flat)](https://twitter.com/zksync)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/matter-labs/zksync-lite-docs/blob/master/LICENSE) [![npm version](https://img.shields.io/npm/v/zksync.svg?style=flat)](https://www.npmjs.com/package/zksync) [![Follow us!](https://img.shields.io/twitter/follow/zksync?color=%238C8DFC&label=Follow%20%40zkSync&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iNDMiIGhlaWdodD0iMjUiIHZpZXdCb3g9IjAgMCA0MyAyNSIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik00Mi42NTM5IDEyLjQ5MTVMMzAuODM3OCAwLjcxNjc0M1Y5LjM0TDE5LjEwNTUgMTcuOTczOUwzMC44Mzc4IDE3Ljk4MlYyNC4yNjYyTDQyLjY1MzkgMTIuNDkxNVoiIGZpbGw9IiM0RTUyOUEiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wLjk5ODA0NyAxMi40ODcyTDEyLjgxNDEgMjQuMjYxOVYxNS43MDhMMjQuNTQ2NSA3LjAwNDdMMTIuODE0MSA2Ljk5NjY0VjAuNzEyNDYzTDAuOTk4MDQ3IDEyLjQ4NzJaIiBmaWxsPSIjOEM4REZDIi8%2BCjwvc3ZnPgo%3D&style=flat)](https://twitter.com/zksync)
 
 
 ## zkSync Documentation for the v1 | [CHANGELOG](./CHANGELOG.md)
@@ -91,9 +91,9 @@ Configuration in `cspell.json`:
 
 ---
 
-# zkSync Ecosystem
+# ZKsync Ecosystem
 
-- [**Start building with zkSync v2 🚀**](https://portal.zksync.io)
+- [**Start building with ZKsync v2 🚀**](https://portal.zksync.io)
 - [Integration Docs](https://docs.lite.zksync.io/dev)
 - [Available API & protocols](https://docs.lite.zksync.io/api/)
 - [zkWallet](https://lite.zksync.io/)
@@ -103,7 +103,7 @@ Configuration in `cspell.json`:
 
 ---
 
-- [Matter Labs: creators of the zkSync](https://matter-labs.io)
+- [Matter Labs: creators of the ZKsync](https://matter-labs.io)
 - [ZKsync  Homepage](https://zksync.io)
 
 ---

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -14,18 +14,18 @@ export default {
   plugins: [
     'fulltext-search',
      ['vuepress-plugin-canonical', {
-       baseURL: 'https://docs.zksync.io',
+       baseURL: 'https://docs.lite.zksync.io',
        stripExtension: true,
      }],
      ['sitemap', {
-       hostname: 'https://docs.zksync.io',
+       hostname: 'https://docs.lite.zksync.io',
      }],
      ['@mr-hope/seo', <SeoOptions>{
        author: 'Matter Labs',
        twitterID: 'zksync',
        seo: ({ page }) => {
          const pageMeta = page.frontmatter.meta ? Object.fromEntries(page.frontmatter.meta.map(e => [e.name, e.content])) : {};
-         const socialImgPath = 'https://docs.zksync.io/social-image.png';
+         const socialImgPath = 'https://docs.lite.zksync.io/social-image.png';
          const title = pageMeta.title ?? (page.title ? page.title + " | " : "") + "zkSync Lite Documentation";
          const description = pageMeta.description ?? "zkSync Lite is a user-centric zk rollup platform from Matter Labs. It is a scaling solution for Ethereum, already live on Ethereum mainnet";
          return {

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -45,7 +45,7 @@ export default {
      }]
   ],
   themeConfig: {
-    repo: 'matter-labs/zksync-docs',
+    repo: 'matter-labs/zksync-lite-docs',
     editLinks: true,
     docsDir: '/docs',
     logo: '/logo.svg',
@@ -75,8 +75,8 @@ export default {
         text: 'zkSync Lite',
         items: [
           {
-            text: 'zkSync Era',
-            link: 'https://era.zksync.io/docs/'
+            text: 'ZKsync Era',
+            link: 'https://docs.zksync.io'
           },
           {
             text: 'zkSync Lite',

--- a/docs/api/v0.2/README.md
+++ b/docs/api/v0.2/README.md
@@ -3,5 +3,5 @@
 The new API interface for the zkSync network has been recently made available! This API unifies JSON-RPC and REST API
 under one REST interface.
 
-The documentation is available [here](https://docs.zksync.io/apiv02-docs.html) (the re-design will be available in the
+The documentation is available [here](https://docs.zksync.io/build/api-reference) (the re-design will be available in the
 future).

--- a/docs/api/v0.2/README.md
+++ b/docs/api/v0.2/README.md
@@ -3,5 +3,5 @@
 The new API interface for the zkSync network has been recently made available! This API unifies JSON-RPC and REST API
 under one REST interface.
 
-The documentation is available [here](https://docs.zksync.io/build/api-reference) (the re-design will be available in the
+The documentation is available [here](https://docs.lite.zksync.io/apiv02-docs/) (the re-design will be available in the
 future).

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -36,4 +36,4 @@ Thirdly, zkSync has native support of NFTs. You can try it out in our [wallet](h
 Finally, zkSync support is implemented for all the main platforms. Check out our [SDK section](/api/sdk) of docs, and
 start developing with zkSync!
 
-If you need smart contract support, zkSync Era is your go to solution. As of February 2022, zkSync Era Testnet has been live featuring smart contracts in Solidity or reusing existing Solidity code. You can find more details in the [zkSync Era Documentation](https://era.zksync.io/docs)
+If you need smart contract support, zkSync Era is your go to solution. As of February 2022, zkSync Era Testnet has been live featuring smart contracts in Solidity or reusing existing Solidity code. You can find more details in the [zkSync Era Documentation](https://docs.zksync.io)

--- a/docs/dev/contracts/README.md
+++ b/docs/dev/contracts/README.md
@@ -64,7 +64,7 @@ based on a native Ethereum signature, all wallets, even hardware wallets, will w
 
 ### Deployment
 
-zkSync Era Mainnet is here! To get started visit the [ZKsync Era Documentation](https://docs.zksync.io).
+ZKsync Era Mainnet is here! To get started visit the [ZKsync Era Documentation](https://docs.zksync.io).
 
 ## Zinc
 
@@ -90,7 +90,6 @@ closely follow that of [Rust](https://www.rust-lang.org/).
 
 The Zinc compiler uses LLVM as its middle-end and back-end, which provides a powerful set of solutions for code
 optimization.
-
 
 ## Getting help
 

--- a/docs/dev/contracts/README.md
+++ b/docs/dev/contracts/README.md
@@ -64,7 +64,7 @@ based on a native Ethereum signature, all wallets, even hardware wallets, will w
 
 ### Deployment
 
-zkSync Era Mainnet is here! To get started visit the [zkSync Era Documentation](https://era.zksync.io/docs/).
+zkSync Era Mainnet is here! To get started visit the [ZKsync Era Documentation](https://docs.zksync.io).
 
 ## Zinc
 

--- a/docs/userdocs/sc/README.md
+++ b/docs/userdocs/sc/README.md
@@ -1,5 +1,5 @@
 # Smart contracts
 
-zkSync Era now provides highly-efficient, secure, Turing-complete, multi-language smart contract functionality. 
+ZKsync Era now provides highly-efficient, secure, Turing-complete, multi-language smart contract functionality. 
 
-Find out more in the [zkSync Era developer docs](https://era.zksync.io/docs/).
+Find out more in the [ZKsync Era developer docs](https://docs.zksync.io).

--- a/docs/zkevm/README.md
+++ b/docs/zkevm/README.md
@@ -216,7 +216,7 @@ based on a native Ethereum signature, all wallets, even hardware wallets, will w
 
 ### When can I deploy?
 
-To get started visit the [zkSync Era Documentation](https://era.zksync.io/docs/).
+To get started visit the [ZKsync Era Documentation](https://docs.zksync.io).
 
 ### What is the status of Zinc?
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zksync-docs",
+  "name": "zksync-lite-docs",
   "description": "zkSync Lite documentation",
   "private": true,
   "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "2.8.0",
   "license": "MIT",
   "author": "Matter Labs",
-  "homepage": "https://docs.zksync.io",
+  "homepage": "https://docs.lite.zksync.io/",
   "keywords": [
     "zk-rollup",
     "web3",
@@ -54,7 +54,7 @@
     "postinstall": "husky install"
   },
   "bugs": {
-    "url": "https://github.com/matter-labs/zksync-docs/issues"
+    "url": "https://github.com/matter-labs/zksync-lite-docs/issues"
   },
   "dependencies": {
     "markdown-it-footnote": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16238,9 +16238,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zksync-docs@workspace:.":
+"zksync-lite-docs@workspace:.":
   version: 0.0.0-use.local
-  resolution: "zksync-docs@workspace:."
+  resolution: "zksync-lite-docs@workspace:."
   dependencies:
     "@commitlint/cli": ^16.2.1
     "@commitlint/config-conventional": ^16.2.1


### PR DESCRIPTION
Update broken links to working URLs. 
Update links referencing the ZKsync docs and correctly reference ZKsync lite docs.